### PR TITLE
商品一覧表示追加実装[ブランド]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,6 +86,7 @@ gem 'better_errors'
 gem 'binding_of_caller'
 gem 'active_hash'
 gem 'pry-rails'
+gem 'kaminari'
 
 #gem 'therubyracer'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,6 +176,18 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    kaminari (1.1.1)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.1.1)
+      kaminari-activerecord (= 1.1.1)
+      kaminari-core (= 1.1.1)
+    kaminari-actionview (1.1.1)
+      actionview
+      kaminari-core (= 1.1.1)
+    kaminari-activerecord (1.1.1)
+      activerecord
+      kaminari-core (= 1.1.1)
+    kaminari-core (1.1.1)
     kgio (2.11.3)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -348,6 +360,7 @@ DEPENDENCIES
   haml-rails
   jbuilder (~> 2.5)
   jquery-rails
+  kaminari
   listen (>= 3.0.5, < 3.2)
   mini_magick
   mysql2 (>= 0.4.4, < 0.6.0)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -10,6 +10,7 @@
 @import "modules/footer";
 @import "modules/sell_btn";
 @import "modules/new";
+@import "modules/brand";
 
 @import "modules/category_downlist";
 

--- a/app/assets/stylesheets/modules/_brand.scss
+++ b/app/assets/stylesheets/modules/_brand.scss
@@ -1,0 +1,38 @@
+.brands{
+  background: lightsteelblue;
+
+  &__main{
+    width: 800px;
+    margin: 0px auto;
+    padding: 25px 0;
+  
+  &__title {
+    padding: 8px 0;
+    font-size: 18px;
+  }
+
+  &__links {
+    display: flex;
+    flex-wrap: wrap;
+    text-align: center;
+    a{
+    border-radius: 4px;
+    min-width: 80px;
+    height: 40px;
+    box-shadow: 1px 1px 1px 1px rgba(14,14,14,0.0580392);
+    padding: 0 30px;
+    margin: 5px;
+    color: black;
+    font-size: 16px;
+    line-height: 40px;
+    text-align: center;
+    background-color: white;
+    &:hover {
+      background: lightcoral;
+      color: white;
+    }
+    }
+  }
+  }
+}
+

--- a/app/assets/stylesheets/modules/_category_all_items.scss
+++ b/app/assets/stylesheets/modules/_category_all_items.scss
@@ -9,3 +9,11 @@
     margin-right: 20px;
   }
 }
+
+.pagination {
+  text-align: center;
+  background-color: whitesmoke;
+  font-size: 20px;
+  padding-bottom: 30px;
+  
+}

--- a/app/assets/stylesheets/modules/_category_all_items.scss
+++ b/app/assets/stylesheets/modules/_category_all_items.scss
@@ -1,7 +1,7 @@
-.categoryROOT{
-  margin-top: 50px;
-  margin-bottom: 50px;
+.root{
+  margin: 50px 30px;
   display:flex;
+  font-size: 18px;
   &__title{
   }
   &__arrow{

--- a/app/controllers/brands_controller.rb
+++ b/app/controllers/brands_controller.rb
@@ -1,0 +1,5 @@
+class BrandsController < ApplicationController
+  def index
+  end
+
+end

--- a/app/controllers/brands_controller.rb
+++ b/app/controllers/brands_controller.rb
@@ -7,4 +7,10 @@ class BrandsController < ApplicationController
     @items5 = Item.where(brand_id:5).order("id DESC").last(10)
   end
 
+  def list
+    @brandsNAME = []
+    @items = Item.where(brand_id: params[:id]).order("id DESC")
+    @brandsNAME << Brand.find(params[:id]).name
+  end
+
 end

--- a/app/controllers/brands_controller.rb
+++ b/app/controllers/brands_controller.rb
@@ -7,7 +7,7 @@ class BrandsController < ApplicationController
     @items5 = Item.where(brand_id:5).order("id DESC").last(10)
   end
 
-  def list
+  def show
     @brandsNAME = []
     @items = Item.where(brand_id: params[:id]).order("id DESC")
     @brandsNAME << Brand.find(params[:id]).name

--- a/app/controllers/brands_controller.rb
+++ b/app/controllers/brands_controller.rb
@@ -1,5 +1,10 @@
 class BrandsController < ApplicationController
   def index
+    @items1 = Item.where(brand_id:1).order("id DESC").last(10)
+    @items2 = Item.where(brand_id:2).order("id DESC").last(10)
+    @items3 = Item.where(brand_id:3).order("id DESC").last(10)
+    @items4 = Item.where(brand_id:4).order("id DESC").last(10)
+    @items5 = Item.where(brand_id:5).order("id DESC").last(10)
   end
 
 end

--- a/app/controllers/brands_controller.rb
+++ b/app/controllers/brands_controller.rb
@@ -9,7 +9,7 @@ class BrandsController < ApplicationController
 
   def show
     @brandsNAME = []
-    @items = Item.where(brand_id: params[:id]).order("id DESC")
+    @items = Item.where(brand_id: params[:id]).order("id DESC").page(params[:page]).per(100)
     @brandsNAME << Brand.find(params[:id]).name
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -78,6 +78,7 @@ class ItemsController < ApplicationController
     @items = self_progeny.map(&:items)
     # 配列の平坦化
     @items.flatten!
+    @items = Item.page(params[:page]).per(100)
   end
 
   def show

--- a/app/views/brands/index.html.haml
+++ b/app/views/brands/index.html.haml
@@ -18,7 +18,7 @@
         .goods__new__item__box__category
           シャネル新着アイテム
         .goods__new__item__box__more
-          =link_to"もっと見る ＞",""
+          =link_to"もっと見る ＞","/brands/1"
       .goods__new__item__list
         - @items1.each do |item|
           = link_to item_path(id: item.id) ,class:"goods__new__item__list__show" do
@@ -41,7 +41,7 @@
         .goods__new__item__box__category
           ナイキ新着アイテム
         .goods__new__item__box__more
-          =link_to"もっと見る ＞",""
+          =link_to"もっと見る ＞","/brands/2"
       .goods__new__item__list
         - @items2.each do |item|
           = link_to item_path(id: item.id),class:"goods__new__item__list__show" do
@@ -64,7 +64,7 @@
         .goods__new__item__box__category
           ルイヴィトン新着アイテム
         .goods__new__item__box__more
-          =link_to"もっと見る ＞",""
+          =link_to"もっと見る ＞","/brands/3"
       .goods__new__item__list
         - @items3.each do |item|
           = link_to item_path(id: item.id),class:"goods__new__item__list__show" do
@@ -87,7 +87,7 @@
         .goods__new__item__box__category
           シュプリーム新着アイテム
         .goods__new__item__box__more
-          =link_to"もっと見る ＞",""
+          =link_to"もっと見る ＞","/brands/4"
       .goods__new__item__list
         - @items4.each do |item|
           = link_to item_path(id: item.id),class:"goods__new__item__list__show" do
@@ -110,7 +110,7 @@
         .goods__new__item__box__category
           アディダス新着アイテム
         .goods__new__item__box__more
-          =link_to"もっと見る ＞",""
+          =link_to"もっと見る ＞","/brands/5"
       .goods__new__item__list
         - @items5.each do |item|
           = link_to item_path(id: item.id),class:"goods__new__item__list__show" do

--- a/app/views/brands/index.html.haml
+++ b/app/views/brands/index.html.haml
@@ -1,8 +1,133 @@
-.container
-  .container__categories
-    .container__categories__visible
-      %h2.container__categories__visible__h2
-        = "ブランド一覧"
-      .container__categories__visible__clearfix
-        - @brands.each do |brand|
-          = link_to brand.name, brand_path(brand.id), id: brand.id, class: "container__categories__visible__clearfix__link"
+= render "items/header"
+
+.brands
+  .brands__main
+    .brands__main__title
+      %h3="ブランド一覧"
+
+    .brands__main__links
+      = link_to "シャネル", "#chanel"
+      = link_to "ナイキ", "#nike"
+      = link_to "ルイヴィトン", "#louisvuitton"
+      = link_to "シュプリーム", "#supreme"
+      = link_to "アディダス", "#adidas"
+  .goods__new
+    .goods__new__item
+      .goods__new__item__box#chanel
+        .goods__new__item__box__category
+          シャネル新着アイテム
+        .goods__new__item__box__more
+          =link_to"もっと見る ＞",""
+      .goods__new__item__list
+        - @items1.each do |item|
+          = link_to item_path(id: item.id) ,class:"goods__new__item__list__show" do
+            .goods__new__item__list__show__image
+              = image_tag (item.item_images[0].image.url),size: "184x184"
+            .goods__box__lists__list__anchor1__content
+              .goods__box__lists__list__anchor1__content__name
+                =item.name
+            .goods__box__lists__list__anchor1__content__description
+              %ul
+                %li
+                  = item.price
+                  円
+            -if item.buyer_id.present?
+              .items__sold
+                .items__sold__inner
+                  SOLD
+
+      .goods__new__item__box#nike
+        .goods__new__item__box__category
+          ナイキ新着アイテム
+        .goods__new__item__box__more
+          =link_to"もっと見る ＞",""
+      .goods__new__item__list
+        - @items2.each do |item|
+          = link_to item_path(id: item.id),class:"goods__new__item__list__show" do
+            .goods__new__item__list__show__image
+              = image_tag (item.item_images[0].image.url),size: "184x184"
+            .goods__box__lists__list__anchor1__content
+              .goods__box__lists__list__anchor1__content__name
+                =item.name
+            .goods__box__lists__list__anchor1__content__description
+              %ul
+                %li
+                  = item.price
+                  円
+            -if item.buyer_id.present?
+              .items__sold
+                .items__sold__inner
+                  SOLD
+
+      .goods__new__item__box#louisvuitton
+        .goods__new__item__box__category
+          ルイヴィトン新着アイテム
+        .goods__new__item__box__more
+          =link_to"もっと見る ＞",""
+      .goods__new__item__list
+        - @items3.each do |item|
+          = link_to item_path(id: item.id),class:"goods__new__item__list__show" do
+            .goods__new__item__list__show__image
+              = image_tag (item.item_images[0].image.url),size: "184x184"
+            .goods__box__lists__list__anchor1__content
+              .goods__box__lists__list__anchor1__content__name
+                =item.name
+            .goods__box__lists__list__anchor1__content__description
+              %ul
+                %li
+                  = item.price
+                  円
+            -if item.buyer_id.present?
+              .items__sold
+                .items__sold__inner
+                  SOLD
+
+      .goods__new__item__box#supreme
+        .goods__new__item__box__category
+          シュプリーム新着アイテム
+        .goods__new__item__box__more
+          =link_to"もっと見る ＞",""
+      .goods__new__item__list
+        - @items4.each do |item|
+          = link_to item_path(id: item.id),class:"goods__new__item__list__show" do
+            .goods__new__item__list__show__image
+              = image_tag (item.item_images[0].image.url),size: "184x184"
+            .goods__box__lists__list__anchor1__content
+              .goods__box__lists__list__anchor1__content__name
+                =item.name
+            .goods__box__lists__list__anchor1__content__description
+              %ul
+                %li
+                  = item.price
+                  円
+            -if item.buyer_id.present?
+              .items__sold
+                .items__sold__inner
+                  SOLD
+
+      .goods__new__item__box#adidas
+        .goods__new__item__box__category
+          アディダス新着アイテム
+        .goods__new__item__box__more
+          =link_to"もっと見る ＞",""
+      .goods__new__item__list
+        - @items5.each do |item|
+          = link_to item_path(id: item.id),class:"goods__new__item__list__show" do
+            .goods__new__item__list__show__image
+              = image_tag (item.item_images[0].image.url),size: "184x184"
+            .goods__box__lists__list__anchor1__content
+              .goods__box__lists__list__anchor1__content__name
+                =item.name
+            .goods__box__lists__list__anchor1__content__description
+              %ul
+                %li
+                  = item.price
+                  円
+            -if item.buyer_id.present?
+              .items__sold
+                .items__sold__inner
+                  SOLD
+
+= render "items/bottom_banner"
+= render "items/footer"
+= render "items/sell_btn"

--- a/app/views/brands/index.html.haml
+++ b/app/views/brands/index.html.haml
@@ -11,6 +11,7 @@
       = link_to "ルイヴィトン", "#louisvuitton"
       = link_to "シュプリーム", "#supreme"
       = link_to "アディダス", "#adidas"
+
   .goods__new
     .goods__new__item
       .goods__new__item__box#chanel

--- a/app/views/brands/index.html.haml
+++ b/app/views/brands/index.html.haml
@@ -1,0 +1,8 @@
+.container
+  .container__categories
+    .container__categories__visible
+      %h2.container__categories__visible__h2
+        = "ブランド一覧"
+      .container__categories__visible__clearfix
+        - @brands.each do |brand|
+          = link_to brand.name, brand_path(brand.id), id: brand.id, class: "container__categories__visible__clearfix__link"

--- a/app/views/brands/list.html.haml
+++ b/app/views/brands/list.html.haml
@@ -1,11 +1,11 @@
 .categoryROOT
   .categoryROOT__title
-    カテゴリー
-  - @categorysNAME.each do |categoryNAME|
+    ブランド
+  - @brandsNAME.each do |brandsNAME|
     .categoryROOT__arrow
       = ">"
     .categoryROOT__name
-      = categoryNAME
+      = brandsNAME
 .goods__new
   .goods__new__item
     .goods__new__item__box

--- a/app/views/brands/show.html.haml
+++ b/app/views/brands/show.html.haml
@@ -30,6 +30,7 @@
               .items__sold
                 .items__sold__inner
                   SOLD
+= paginate(@items)
 
 = render "items/bottom_banner"
 = render "items/footer"

--- a/app/views/brands/show.html.haml
+++ b/app/views/brands/show.html.haml
@@ -1,10 +1,12 @@
-.categoryROOT
-  .categoryROOT__title
+= render "items/header"
+
+.root
+  .root__title
     ブランド
   - @brandsNAME.each do |brandsNAME|
-    .categoryROOT__arrow
+    .root__arrow
       = ">"
-    .categoryROOT__name
+    .root__name
       = brandsNAME
 .goods__new
   .goods__new__item
@@ -28,3 +30,7 @@
               .items__sold
                 .items__sold__inner
                   SOLD
+
+= render "items/bottom_banner"
+= render "items/footer"
+= render "items/sell_btn"

--- a/app/views/categories/index.html.haml
+++ b/app/views/categories/index.html.haml
@@ -14,16 +14,19 @@
         %h3{id: "category_#{category.id}", class: "categories__main__contents__title"}=category.name
         .categories__main__contents__body
           .categories__main__contents__body__category-all
-            = link_to "すべて"
+            = link_to list_from_category_item_path(category.id) do
+              = "すべて"
           - category.children.each do |category_child|
             .categories__main__contents__body__category-title
               = category_child.name
             .categories__main__contents__body__category-list
               .categories__main__contents__body__category-list__item
-                =link_to "すべて"
+                = link_to list_from_category_item_path(category_child.id) do
+                  = "すべて"
               - category_child.children.each do |category_grandchild|
                 .categories__main__contents__body__category-list__item
-                  =link_to category_grandchild.name
+                  = link_to list_from_category_item_path(category_grandchild.id) do
+                    = category_grandchild.name
 
 = render "items/bottom_banner"
 = render "items/footer"

--- a/app/views/items/_footer.html.haml
+++ b/app/views/items/_footer.html.haml
@@ -17,9 +17,9 @@
         FURIMAを見る
       %ul
         %li
-          = link_to "カテゴリー一覧","#"
+          = link_to "カテゴリー一覧",categories_path
         %li
-          = link_to "ブランド一覧","#"
+          = link_to "ブランド一覧",brands_path
     %li.footer__contents__content
       %h2.footer__contents__content__head
         ヘルプ＆ガイド

--- a/app/views/items/_header.html.haml
+++ b/app/views/items/_header.html.haml
@@ -19,7 +19,7 @@
         .list-left__item-first
           = link_to 'カテゴリー', categories_path, class: "category-btn headerlink"
         .list-left__item-second
-          = link_to "ブランド", "#", class:"brand-btn headerlink"
+          = link_to "ブランド", brands_path, class:"brand-btn headerlink"
         .list-left__item-second
           = link_to "ホーム","/", class:"brand-btn headerlink"
         .list-left__item-second

--- a/app/views/items/template_category/_category_show.html.haml
+++ b/app/views/items/template_category/_category_show.html.haml
@@ -28,3 +28,4 @@
               .items__sold
                 .items__sold__inner
                   SOLD
+= paginate(@items) 

--- a/app/views/items/template_category/_category_show.html.haml
+++ b/app/views/items/template_category/_category_show.html.haml
@@ -1,10 +1,10 @@
-.categoryROOT
-  .categoryROOT__title
+.root
+  .root__title
     カテゴリー
   - @categorysNAME.each do |categoryNAME|
-    .categoryROOT__arrow
+    .root__arrow
       = ">"
-    .categoryROOT__name
+    .root__name
       = categoryNAME
 .goods__new
   .goods__new__item

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,12 @@ Rails.application.routes.draw do
 
   resources :categories, only: [:index] 
 
-  resources :brands, only: [:index] 
+  resources :brands, only: [:index] do
+    member do
+      get  'list'
+     end
+   end
+
 
   resources :cards, only:[:index, :new, :create,:destroy,:show] do
     member do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,8 @@ Rails.application.routes.draw do
 
   resources :categories, only: [:index] 
 
+  resources :brands, only: [:index] 
+
   resources :cards, only:[:index, :new, :create,:destroy,:show] do
     member do
       post 'pay'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,12 +21,7 @@ Rails.application.routes.draw do
 
   resources :categories, only: [:index] 
 
-  resources :brands, only: [:index] do
-    member do
-      get  'list'
-     end
-   end
-
+  resources :brands, only: [:index,:show] 
 
   resources :cards, only:[:index, :new, :create,:destroy,:show] do
     member do


### PR DESCRIPTION
# What
ヘッダーの「ブランド」からブランド一覧ページ→商品一覧ページと遷移するように実装。
カテゴリ一覧ページから商品一覧ページへの遷移できていなかったところもできるようにした。
商品一覧ページにページネーションを実装（100件以上になると次ページができます）

# Why
ブランド、カテゴリーからさくっと商品が探せるように。
