### PR TITLE
パスワードの表示/非表示

### DIFF
--- a/app/assets/javascripts/registrations_new.js
+++ b/app/assets/javascripts/registrations_new.js
@@ -1,0 +1,14 @@
+$(function(){
+  var password = '#password';
+  var passcheck = '#js-passcheck';
+  $(passcheck).change(function(){
+    const passwordLabel = document.querySelector('.js-password-label');
+    if ($(this).prop('checked')){
+      $(password).attr('type','text');
+      passwordLabel.innerHTML = '<i class="fas fa-eye-slash" style="font-size:20px;color:#808080"></i>';
+    } else {
+      $(password).attr('type','password');
+      passwordLabel.innerHTML = '<i class="fas fa-eye" style="font-size:20px;color:#808080"></i>';
+    }
+  })
+})

--- a/app/assets/javascripts/registrations_new.js
+++ b/app/assets/javascripts/registrations_new.js
@@ -5,10 +5,10 @@ $(function(){
     const passwordLabel = document.querySelector('.js-password-label');
     if ($(this).prop('checked')){
       $(password).attr('type','text');
-      passwordLabel.innerHTML = '<i class="fas fa-eye-slash" style="font-size:20px;color:#808080"></i>';
+      passwordLabel.innerHTML = '<i class="fas fa-eye" style="font-size:20px;color:#808080"></i>';
     } else {
       $(password).attr('type','password');
-      passwordLabel.innerHTML = '<i class="fas fa-eye" style="font-size:20px;color:#808080"></i>';
+      passwordLabel.innerHTML = '<i class="fas fa-eye-slash" style="font-size:20px;color:#808080"></i>';
     }
   })
 })

--- a/app/assets/stylesheets/modules/_user.scss
+++ b/app/assets/stylesheets/modules/_user.scss
@@ -36,6 +36,17 @@
       vertical-align: top;
       font-weight: 600;
     }
+    .toggle{ 
+      position: relative;
+      .checkbox-field{
+        position: absolute;
+        right: 15px;
+        top: 45px;
+        .checkbox {
+          display: none;
+        }
+      }
+    }
     #user_birthday_1i {
       width: 76px;
       margin: 8px 0 0;
@@ -255,6 +266,17 @@
     .field-label{
       font-weight: bold;
       float: left;
+    }
+    .toggle{ 
+      position: relative;
+      .checkbox-field{
+        position: absolute;
+        right: 15px;
+        top: 45px;
+        .checkbox {
+          display: none;
+        }
+      }
     }
     .field-input-full {
       width: 100%;

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -27,8 +27,12 @@
                 .field-label 
                   = f.label 'パスワード'
                   %span.form-require 必須
-                .field-input
-                  = f.password_field :password, class: "field-input-full", autocomplete: "off", autocomplete: "password", placeholder: "7文字以上の半角英数字"
+                .field-input.toggle
+                  = f.password_field :password, class: "field-input-full", autocomplete: "off", autocomplete: "password", placeholder: "7文字以上の半角英数字", id:'password'
+                  .checkbox-field
+                    %input#js-passcheck.checkbox.js-password-toggle{type: "checkbox"}
+                    %label.btn-label.js-password-label{for: "js-passcheck"}
+                      %i.fas.fa-eye{style: "font-size:20px;color:#808080"}
                 .field-info
                   ※ 英字と数字の両方を含めて設定してください
               .field

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -32,7 +32,7 @@
                   .checkbox-field
                     %input#js-passcheck.checkbox.js-password-toggle{type: "checkbox"}
                     %label.btn-label.js-password-label{for: "js-passcheck"}
-                      %i.fas.fa-eye{style: "font-size:20px;color:#808080"}
+                      %i.fas.fa-eye-slash{style: "font-size:20px;color:#808080"}
                 .field-info
                   ※ 英字と数字の両方を含めて設定してください
               .field

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -23,7 +23,7 @@
                   .checkbox-field
                     %input#js-passcheck.checkbox.js-password-toggle{type: "checkbox"}
                     %label.btn-label.js-password-label{for: "js-passcheck"}
-                      %i.fas.fa-eye{style: "font-size:20px;color:#808080"}
+                      %i.fas.fa-eye-slash{style: "font-size:20px;color:#808080"}
               .actions
                 = f.submit "ログイン", class: 'btn'
   %header.login__footer

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -18,8 +18,12 @@
               .field
                 .field-label
                   = f.label :password
-                .field-input
-                  = f.password_field :password, class: "field-input-full", autocomplete: "off", placeholder: "パスワード"
+                .field-input.toggle
+                  = f.password_field :password, class: "field-input-full", autocomplete: "off", placeholder: "パスワード", id:'password'
+                  .checkbox-field
+                    %input#js-passcheck.checkbox.js-password-toggle{type: "checkbox"}
+                    %label.btn-label.js-password-label{for: "js-passcheck"}
+                      %i.fas.fa-eye{style: "font-size:20px;color:#808080"}
               .actions
                 = f.submit "ログイン", class: 'btn'
   %header.login__footer


### PR DESCRIPTION
#What
ユーザー新規登録/ログイン機能について、入力したパスワードの「表示/非表示」を切り替えられるように実装。
[![Screenshot from Gyazo](https://gyazo.com/7b23d3cefeb13543872f6274af0b4e3d/raw)](https://gyazo.com/7b23d3cefeb13543872f6274af0b4e3d)
[![Screenshot from Gyazo](https://gyazo.com/e0ae56ea00db0db39e3005fbb55daa54/raw)](https://gyazo.com/e0ae56ea00db0db39e3005fbb55daa54)
#Why
パスワードの打ち間違えを確認できるようにもできた方が、ユーザービリティが向上する。